### PR TITLE
Used reqwest::Client's default header system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 #[tokio::main]
 pub async fn main() {
-    let api = DestinyAPI::new(&env::var("API_KEY").unwrap());
+    let api = DestinyAPI::new(&env::var("API_KEY").unwrap()).unwrap();
 
     let mut manifest_path = PathBuf::new();
     manifest_path.push("./manifest");

--- a/src/models/api.rs
+++ b/src/models/api.rs
@@ -61,7 +61,6 @@ use {
 };
 
 pub struct DestinyAPI {
-    api_key: String,
     client: reqwest::Client,
 }
 
@@ -77,11 +76,15 @@ struct DownloadedDatabase {
 }
 
 impl DestinyAPI {
-    pub fn new(key: &str) -> DestinyAPI {
-        DestinyAPI {
-            api_key: key.to_string(),
-            client: reqwest::Client::new(),
-        }
+    pub fn new(key: &str) -> Result<DestinyAPI> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "X-API-Key",
+            reqwest::header::HeaderValue::from_str(key)?,
+        );
+        Ok(DestinyAPI {
+            client: reqwest::Client::builder().default_headers(headers).build()?,
+        })
     }
 
     pub async fn get_user_by_bungie_net_id<T: BNGMembershipID>(&self, id: &T) -> Result<GeneralUser> {
@@ -139,7 +142,6 @@ impl DestinyAPI {
             println!("API_CALL: {}/{}", API_BASE_URL, url.to_string());
         }
         let raw_response = self.client.get(&format!("{}/{}", API_BASE_URL, url.to_string()))
-            .header("X-Api-Key", self.api_key.clone())
             .send()
             .await?
             .text()

--- a/src/test/api.rs
+++ b/src/test/api.rs
@@ -10,7 +10,7 @@ const STEAM_ID: &str = "76561198261302803";
 
 #[test]
 fn get_by_steamid64() {
-    let api = DestinyAPI::new(&env::var("BUNGIE_API_KEY").unwrap());
+    let api = DestinyAPI::new(&env::var("BUNGIE_API_KEY").unwrap()).unwrap();
     let usr = block_on(api.get_user_by_steamid64(&STEAM_ID)).unwrap();
     assert_eq!(usr.bungie_net_user.membership_id, 19377351);
 }

--- a/src/test/manifest.rs
+++ b/src/test/manifest.rs
@@ -67,7 +67,7 @@ fn manifest_keys() {
         ManifestKey::VendorGroup
     ];
 
-    let api = DestinyAPI::new(&std::env::var("BUNGIE_API_KEY").unwrap());
+    let api = DestinyAPI::new(&std::env::var("BUNGIE_API_KEY").unwrap()).unwrap();
     let mut manifest_path = PathBuf::new();
     // TODO: this probabbly breaks windows
     manifest_path.push(std::env::var("HOME").unwrap());


### PR DESCRIPTION
If you use the Client's builder struct, you can set the default header for every request, instead of setting the header every time. This also means the api_key doesn't neeed to be stored directly in the struct. The reqwest::header::HeaderValue::from_str method onlly returns an error when the key has an invalid header character (anything that isn't a visible ASCII character).

Default headers docs: https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.default_headers
HeaderValue::from_str docs: https://docs.rs/reqwest/latest/reqwest/header/struct.HeaderValue.html#method.from_str